### PR TITLE
Potential fix for code scanning alert no. 3: Reflected cross-site scripting

### DIFF
--- a/11-advanced-recipes/09-cpu-bound/index.js
+++ b/11-advanced-recipes/09-cpu-bound/index.js
@@ -1,5 +1,6 @@
 import { createServer } from 'node:http'
 import { SubsetSum } from './subsetSum.js'
+import escape from 'escape-html'
 // import { SubsetSum } from './subsetSumDefer.js'
 // import { SubsetSum } from './subsetSumFork.js'
 // import { SubsetSum } from './subsetSumThreads.js'
@@ -17,7 +18,7 @@ createServer((req, res) => {
   const subsetSum = new SubsetSum(sum, data)
   subsetSum.on('match', match => {
     res.cork()
-    res.write(`Match: ${JSON.stringify(match)}\n`)
+    res.write(`Match: ${escape(JSON.stringify(match))}\n`)
     res.uncork()
   })
   subsetSum.on('end', () => res.end())

--- a/11-advanced-recipes/09-cpu-bound/package.json
+++ b/11-advanced-recipes/09-cpu-bound/package.json
@@ -11,5 +11,7 @@
   "keywords": [],
   "author": "Luciano Mammino and Mario Casciaro",
   "license": "MIT",
-  "dependencies": {}
+  "dependencies": {
+    "escape-html": "^1.0.3"
+  }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Design-Patterns-Fourth-Edition/security/code-scanning/3](https://github.com/ibiscum/Node.js-Design-Patterns-Fourth-Edition/security/code-scanning/3)

To fix the problem, we need to ensure that user input is either sanitized or encoded before being incorporated into HTTP responses, particularly when written to the body. Since the user-controlled value (`match`) is being serialized with `JSON.stringify`, but still injected into a template literal, an attacker might be able to inject malicious strings if the input array is made up of strings instead of only numbers.

The best fix here is to escape any untrusted data before including it in any response. The `escape-html` library is a well-known solution for encoding text so that it is safe to render in HTML. Even if you intend to return plain text, browsers may sometimes interpret non-HTML Content-Type as HTML under some circumstances, so escaping is best practice.

Therefore, change the code to wrap `JSON.stringify(match)` in an escaping function before inserting it into the response. Additionally, ensure that `escape-html` is imported at the top.

Edits needed:
- In `11-advanced-recipes/09-cpu-bound/index.js`, add import for `escape-html`.
- Replace line that does:  
  ```js
  res.write(`Match: ${JSON.stringify(match)}\n`)
  ```
  with:
  ```js
  res.write(`Match: ${escape(JSON.stringify(match))}\n`)
  ```
  (using the `escape` function from the `escape-html` library).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
