### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,4 +1,6 @@
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Design-Patterns-Fourth-Edition/security/code-scanning/4](https://github.com/ibiscum/Node.js-Design-Patterns-Fourth-Edition/security/code-scanning/4)

The best fix is to explicitly specify a minimal `permissions` block at the top level of the workflow to restrict the default permissions of the GITHUB_TOKEN to only those necessary for the workflow's operation. For workflows that only read repository contents (e.g., check out source code, run tests), the correct configuration is usually `contents: read`, which prevents any accidental write access to repository assets.  

**How to fix:**  
Insert a `permissions:` block at the workflow root (between `name:` and `on:`) with its value set to `contents: read`. This ensures all jobs that do not specify their own `permissions` block inherit this restrictive policy.  
**Where to change:**  
Within `.github/workflows/node.yml`, insert after line 1 (after `name: Node.js CI`), as recommended by the documentation and CodeQL guidance.  
**What is needed:**  
No external dependencies, imports, or function changes are necessary; just the explicit YAML addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
